### PR TITLE
Kanji für Abend ausgetauscht

### DIFF
--- a/deck.json
+++ b/deck.json
@@ -3420,7 +3420,7 @@
             "__type__": "Note",
             "fields": [
                 "114",
-                "タ",
+                "夕",
                 "Abend",
                 "Die Zeit, bevor der <i>Mond</i> ganz aufgezogen ist (hier noch <i>teilweise von Wolken verdeckt, namentlich der letzte Strich</i>).",
                 "Abend",


### PR DESCRIPTION
Hi, vorab erst einmal vielen Dank für dein Deck!

Als ich gerade mit einem Skript versucht habe, meine Vokabelkarten anhand der RTK-Karten freizuschalten, fiel mir auf, dass eine Karte im RTK-Deck existiert, bei der in meinem Skript kein Kanji gefunden wurde.

Und zwar wurde in der Karte für "Abend" leider anstelle des eigentlichen Kanjis, das nahezu gleichaussehende Katakana-た verwendet. Meine Änderung umfasst darum nur:
(Unicode) 30BF -> 5915

Schönes Wochenende!